### PR TITLE
Adjust Bootloader Descriptor Address

### DIFF
--- a/link-imxrt.x
+++ b/link-imxrt.x
@@ -11,11 +11,9 @@ MEMORY {
   FLASH              : ORIGIN = 0x08001000, LENGTH = 1M
 }
 
-/* link descriptors at FLASH address after __bootloader_max_size */
-__bootable_region_descriptors_address = ORIGIN(FLASH) + __bootloader_max_size;
+/* link descriptors at FLASH address after 32KB Bootloader Range */
+__bootable_region_descriptors_address = 0x08009000;
 
-__bootloader_max_size  = LENGTH(IRAM); /* for debug image loading */
-__bootloader_data_size = LENGTH(RAM);  /* for RAM buffering as needed */
 __bootloader_ivec_size = 0x130;        /*  */
 
 /* # Entry point = reset vector */

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ fn copy_image(_app_descriptor: &AppImageDescriptor) {
         raw_copy_to_ram(
             _app_descriptor.stored_address as *const u32,
             _app_descriptor.execution_address as *mut u32,
-            _app_descriptor.execution_copy_size_bytes as usize,
+            _app_descriptor.execution_copy_size_bytes as usize / size_of::<u32>(),
         );
     }
 }


### PR DESCRIPTION
Fixes a bug with Flexspi interface and the length of the copy to RAM