### PR TITLE
Fixed writing to OTP registers smaller than 32 bits

### DIFF
--- a/libs/imxrt-rom/src/registers.rs
+++ b/libs/imxrt-rom/src/registers.rs
@@ -21,8 +21,17 @@ pub struct ShadowInterface {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct NotShadowRegister;
 
+/// The index of an OTP word as defined in the OTP Fuse Map -- 220315.
+type OtpWordIndex = u32;
+
+/// A single OTP word as required by the OTP API.
+///
+/// Note that an OTP register can be smaller than 32 bits.
+/// The API however requires the register to then be stretched to 32 bits before being written.
+type OtpWord = u32;
+
 /// Convert an OTP word index to offset in the shadow register block.
-const fn otp_to_shadow_offset(otp_word_i: u32) -> Result<usize, NotShadowRegister> {
+const fn otp_to_shadow_offset(otp_word_i: OtpWordIndex) -> Result<usize, NotShadowRegister> {
     let shadow_offset = match otp_word_i {
         8..=9 => (otp_word_i - 8) * 4 + 0x020,
         95..=104 => (otp_word_i - 95) * 4 + 0x17C,
@@ -35,14 +44,50 @@ const fn otp_to_shadow_offset(otp_word_i: u32) -> Result<usize, NotShadowRegiste
 }
 
 /// Convert an OTP word index to address in the shadow register block.
-fn otp_to_shadow_addr(otp_word_i: u32) -> Result<*mut u32, NotShadowRegister> {
+fn otp_to_shadow_addr(otp_word_i: OtpWordIndex) -> Result<*mut u32, NotShadowRegister> {
     const OTP_SHADOW_BASE_ADDR: usize = 0x40130000;
     Ok((OTP_SHADOW_BASE_ADDR + otp_to_shadow_offset(otp_word_i)?) as *mut u32)
 }
 
+/// Converts a slice into a sequence of words to be written to either shadow registers or OTP fuses.
+fn data_to_otp_words(otp_word_i: OtpWordIndex, data: &[u8]) -> impl Iterator<Item = (OtpWordIndex, OtpWord)> + '_ {
+    data.chunks(core::mem::size_of::<OtpWord>())
+        .enumerate()
+        .map(move |(chunk_i, chunk)| {
+            let otp_word_i = otp_word_i + chunk_i as u32;
+
+            let word = if chunk.len() < core::mem::size_of::<OtpWord>() {
+                let mut buf = [0u8; core::mem::size_of::<OtpWord>()];
+                buf[..chunk.len()].copy_from_slice(chunk);
+                OtpWord::from_le_bytes(buf)
+            } else {
+                // Safety: we have chunks of exactly core::mem::size_of::<OtpWord>() bytes, hence the conversion to [u8; 4] is safe.
+                OtpWord::from_le_bytes(unsafe { chunk.try_into().unwrap_unchecked() })
+            };
+
+            (otp_word_i, word)
+        })
+}
+
+fn otp_words_to_data<E>(
+    otp_word_i: OtpWordIndex,
+    data: &mut [u8],
+    mut f: impl FnMut(OtpWordIndex) -> Result<OtpWord, E>,
+) -> Result<(), E> {
+    for (chunk_i, chunk) in data.chunks_mut(core::mem::size_of::<OtpWord>()).enumerate() {
+        let otp_word_i = otp_word_i + chunk_i as u32;
+        let word = f(otp_word_i)?.to_le_bytes();
+
+        // Note: if the chunk is smaller (example: 16 bits), only copy the LE bytes at the front of the slice.
+        chunk.copy_from_slice(&word[..chunk.len()]);
+    }
+
+    Ok(())
+}
+
 impl RegisterInterface for ShadowInterface {
     type Error = NotShadowRegister;
-    type AddressType = u32;
+    type AddressType = OtpWordIndex;
 
     fn write_register(
         &mut self,
@@ -50,18 +95,8 @@ impl RegisterInterface for ShadowInterface {
         _size_bits: u32,
         data: &[u8],
     ) -> Result<(), Self::Error> {
-        for (chunk_i, chunk) in data.chunks(4).enumerate() {
-            let otp_word_i = otp_word_i + chunk_i as u32;
+        for (otp_word_i, word) in data_to_otp_words(otp_word_i, data) {
             let shadow_addr = otp_to_shadow_addr(otp_word_i)?;
-
-            let word = if chunk.len() != 4 {
-                let mut buf = [0u8; 4];
-                buf[..chunk.len()].copy_from_slice(chunk);
-                u32::from_le_bytes(buf)
-            } else {
-                // Safety: we have chunks of exactly 4 bytes, hence the conversion to [u8; 4] is safe.
-                u32::from_le_bytes(unsafe { chunk.try_into().unwrap_unchecked() })
-            };
 
             // Safety: we assume that the register yaml definition is correct, and that each register is aligned.
             unsafe { shadow_addr.write_volatile(word) };
@@ -75,10 +110,11 @@ impl RegisterInterface for ShadowInterface {
         _size_bits: u32,
         data: &mut [u8],
     ) -> Result<(), Self::Error> {
-        // Safety: we assume that the register yaml definition is correct, no need for volatile memory access.
-        let shadow_addr = otp_to_shadow_addr(otp_word_i)? as *const u8;
-        let source = unsafe { core::slice::from_raw_parts(shadow_addr, data.len()) };
-        data.copy_from_slice(source);
+        otp_words_to_data(otp_word_i, data, |otp_word_i| {
+            let shadow_addr = otp_to_shadow_addr(otp_word_i)? as *const u32;
+            // Safety: we assume that the register yaml definition is correct, and that each register is aligned.
+            Ok(unsafe { shadow_addr.read_volatile() })
+        })?;
         Ok(())
     }
 }
@@ -104,31 +140,32 @@ impl From<crate::otp::Error> for OtpError {
 
 impl RegisterInterface for OtpInterface<'_> {
     type Error = OtpError;
-    type AddressType = u32;
+    type AddressType = OtpWordIndex;
 
-    fn write_register(&mut self, address: Self::AddressType, _size_bits: u32, data: &[u8]) -> Result<(), Self::Error> {
+    fn write_register(
+        &mut self,
+        otp_word_i: Self::AddressType,
+        _size_bits: u32,
+        data: &[u8],
+    ) -> Result<(), Self::Error> {
         if !self.allow_write {
             return Err(OtpError::WriteNotAllowed);
         }
 
-        for (i, chunk) in data.chunks_exact(4).enumerate() {
-            // Safety: we have chunks of exactly 4 bytes, hence the conversion to [u8; 4] is safe.
-            let word = u32::from_le_bytes(unsafe { chunk.try_into().unwrap_unchecked() });
-
-            self.otp.write_fuse(address + i as u32, word, self.mode_locked)?;
+        for (otp_word_i, word) in data_to_otp_words(otp_word_i, data) {
+            self.otp.write_fuse(otp_word_i, word, self.mode_locked)?;
         }
+
         Ok(())
     }
 
     fn read_register(
         &mut self,
-        address: Self::AddressType,
+        otp_word_i: Self::AddressType,
         _size_bits: u32,
         data: &mut [u8],
     ) -> Result<(), Self::Error> {
-        for (i, chunk) in data.chunks_exact_mut(4).enumerate() {
-            chunk.copy_from_slice(&self.otp.read_fuse(address + i as u32)?.to_le_bytes());
-        }
+        otp_words_to_data(otp_word_i, data, |otp_word_i| self.otp.read_fuse(otp_word_i))?;
         Ok(())
     }
 }
@@ -216,5 +253,74 @@ mod tests {
         assert_eq!(otp_to_shadow_offset(101), Ok(0x194)); // SEC_BOOT_CFG[5]
         assert_eq!(otp_to_shadow_offset(120), Ok(0x1E0)); // RKTH[0]
         assert_eq!(otp_to_shadow_offset(127), Ok(0x1FC)); // RKTH[7]
+    }
+
+    /// Test reading registers that are smaller than the OTP fuse word.
+    #[test]
+    fn read_words_partial() {
+        let target = 0x1234u16;
+        let target_buf = target.to_le_bytes();
+
+        assert_eq!(target_buf, [0x34, 0x12]);
+
+        let otp_words: std::vec::Vec<_> = data_to_otp_words(100, &target_buf).collect();
+        assert_eq!(otp_words, [(100, 0x00001234)]);
+    }
+
+    /// Test writing registers that are smaller than the OTP fuse word.
+    #[test]
+    fn write_words_partial() {
+        let mut buf = [0u8; 2];
+        assert!(
+            otp_words_to_data::<core::convert::Infallible>(100, &mut buf, |otp_word_i| {
+                assert_eq!(otp_word_i, 100);
+                Ok(0x00001234)
+            })
+            .is_ok()
+        );
+        assert_eq!(buf, [0x34, 0x12]);
+    }
+
+    const MULTIPLE_DATASET: [(OtpWordIndex, OtpWord); 8] = [
+        (100, 0x04030201),
+        (101, 0x08070605),
+        (102, 0x0C0B0A09),
+        (103, 0x100F0E0D),
+        (104, 0x14131211),
+        (105, 0x18171615),
+        (106, 0x1C1B1A19),
+        (107, 0x201F1E1D),
+    ];
+
+    fn generate_multiple_bytebuf() -> [u8; 32] {
+        let mut target_buf: [u8; 32] = [0u8; 32];
+        for (i, b) in target_buf.iter_mut().enumerate() {
+            *b = (i + 1) as u8;
+        }
+        target_buf
+    }
+
+    /// Test reading registers that are several OTP words large.
+    #[test]
+    fn read_words_multiple() {
+        let otp_words: std::vec::Vec<_> = data_to_otp_words(100, &generate_multiple_bytebuf()).collect();
+        assert_eq!(otp_words, MULTIPLE_DATASET);
+    }
+
+    /// Test writing registers that are several OTP words large.
+    #[test]
+    fn write_words_multiple() {
+        let mut buf = [0u8; 32];
+        assert!(
+            otp_words_to_data::<core::convert::Infallible>(100, &mut buf, |otp_word_i| {
+                let (_, word) = MULTIPLE_DATASET
+                    .into_iter()
+                    .find(move |(i, _)| *i == otp_word_i)
+                    .expect("Register should exist in the dataset");
+                Ok(word)
+            })
+            .is_ok()
+        );
+        assert_eq!(buf, generate_multiple_bytebuf());
     }
 }


### PR DESCRIPTION
We have a single device-driver definition of the OTP fuse registers, but can access them both from shadow registers, as well as from the OTP ROM API. In the OTP ROM API implementation writing to registers smaller than 32 bits did not do anything. See #25.

This is due to calling `chunks_exact` with a size of 4, which does not yield any chunk if the remaining buffer cannot fit exactly that chunk: https://github.com/OpenDevicePartnership/ec-slimloader/blob/76d6f5cc2a422e0aa0a1fcf23a5c81c251276f5a/libs/imxrt-rom/src/registers.rs#L114-L119

This PR streamlines how the OTP words are accessed between OTP ROM API and shadow registers, and adds a few tests to validate that it does so correctly.