### PR TITLE
Update embassy-sync 0.7.2 -> 0.8.0

### DIFF
--- a/examples/rt685s/Cargo.toml
+++ b/examples/rt685s/Cargo.toml
@@ -19,7 +19,7 @@ warnings = "deny"
 embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt.git", default-features = false }
 
 partition-manager = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", default-features = false }
-embassy-sync = "0.7.2"
+embassy-sync = "0.8.0"
 embassy-executor = "0.9.1"
 
 defmt = "1.0.1"

--- a/libs/Cargo.toml
+++ b/libs/Cargo.toml
@@ -20,7 +20,7 @@ manual_let_else = "deny"
 defmt = "0.3.7"
 defmt-or-log = { version = "0.2.2", default-features = false }
 embedded-storage-async = "0.4.1"
-embassy-sync = "0.7.2"
+embassy-sync = "0.8.0"
 log = "0.4"
 
 cortex-m = { version = "0.7.7" }


### PR DESCRIPTION
## Summary
Update workspace embassy-sync dependency from 0.7.2 to 0.8.0.

## Why?
partition-manager (from embedded-services) now uses embassy-sync 0.8's `RawMutex` trait. ec-slimloader-imxrt uses `NoopRawMutex` from embassy-sync with `Partition` types from partition-manager, so both must be on the same embassy-sync version to satisfy trait bounds.

## What changed?
Single line change in `libs/Cargo.toml`: `embassy-sync = "0.7.2"` → `"0.8.0"`

The `NoopRawMutex` API is identical between 0.7 and 0.8, so no code changes are needed.