### PR TITLE
Bump device-driver to 1.0.9

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -75,6 +75,7 @@ ignore = [
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained, no safe upgrade available, need upstream dependencies to migrate away from it." },
+    { id = "RUSTSEC-2026-0110", reason = "bare-metal is deprecated; pulled in transitively, needs upstream migration." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/libs/imxrt-rom/Cargo.toml
+++ b/libs/imxrt-rom/Cargo.toml
@@ -24,7 +24,7 @@ embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt.
     "unstable-pac",
 ] }
 
-device-driver = { version = "1.0", default-features = false, features = [
+device-driver = { version = "1.0.9", default-features = false, features = [
     "json",
 ] }
 


### PR DESCRIPTION
Bumps `device-driver` from 1.0 to 1.0.9 in `libs/imxrt-rom/Cargo.toml`.

- Cargo.lock is not tracked in this repo; `cargo metadata` against the libs workspace confirms the new version resolves cleanly.
- No `supply-chain/` config in this repo, so no cargo-vet certification was needed.
- Added `deny.toml` advisory exception for **RUSTSEC-2026-0110** (`bare-metal` is deprecated). Pulled in transitively; no safe upgrade path until upstream crates migrate. Note: `heapless` 0.8 / 0.9.1 duplicate is also flagged but intentionally not addressed in this PR — it requires coordinated upstream updates and is out of scope for the device-driver bump.