### PR TITLE
Pin ODP deps to v0.1.0

### DIFF
--- a/examples/rt685s/Cargo.toml
+++ b/examples/rt685s/Cargo.toml
@@ -16,9 +16,9 @@ repository = "https://github.com/OpenDevicePartnership/ec-slimloader"
 warnings = "deny"
 
 [workspace.dependencies]
-embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt.git", default-features = false }
+embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt.git", tag = "v0.1.0", default-features = false }
 
-partition-manager = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", default-features = false }
+partition-manager = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", tag = "v0.1.0", default-features = false }
 embassy-sync = "0.8.0"
 embassy-executor = "0.9.1"
 

--- a/libs/ec-slimloader-imxrt/Cargo.toml
+++ b/libs/ec-slimloader-imxrt/Cargo.toml
@@ -61,7 +61,7 @@ ec-slimloader-state = { path = "../ec-slimloader-state", default-features = fals
 imxrt-rom = { path = "../imxrt-rom", features = ["rt"] }
 
 cortex-m = { workspace = true }
-embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt.git", default-features = false, features = [
+embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt.git", tag = "v0.1.0", default-features = false, features = [
     "unstable-pac",
 ] }
 
@@ -74,7 +74,7 @@ log = { workspace = true, optional = true }
 embassy-embedded-hal = "0.5.0"
 
 embassy-sync = { workspace = true }
-partition-manager = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", features = [
+partition-manager = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", tag = "v0.1.0", features = [
     "esa",
     "macros",
 ], default-features = false }

--- a/libs/imxrt-rom/Cargo.toml
+++ b/libs/imxrt-rom/Cargo.toml
@@ -20,7 +20,7 @@ defmt-or-log = { workspace = true }
 log = { workspace = true, optional = true }
 
 cortex-m = { workspace = true }
-embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt.git", default-features = false, features = [
+embassy-imxrt = { git = "https://github.com/OpenDevicePartnership/embassy-imxrt.git", tag = "v0.1.0", default-features = false, features = [
     "unstable-pac",
 ] }
 


### PR DESCRIPTION
Add tag = "v0.1.0" to git dependencies for embassy-imxrt and partition-manager (embedded-services) across all workspace crates to pin them to the v0.1.0 release.